### PR TITLE
fix: extract JDBC jar by basename

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -221,8 +221,8 @@ func downloadJDBCDriver(url, destDir string) (string, error) {
 	}
 
 	filename := filepath.Base(url)
-	path := filepath.Join(destDir, filename)
-	f, err := os.Create(path)
+	destPath := filepath.Join(destDir, filename)
+	f, err := os.Create(destPath)
 	if err != nil {
 		return "", err
 	}
@@ -232,10 +232,10 @@ func downloadJDBCDriver(url, destDir string) (string, error) {
 	}
 
 	// Validate zip by trying to open.
-	if err := validateZip(path); err != nil {
+	if err := validateZip(destPath); err != nil {
 		return "", err
 	}
-	return path, nil
+	return destPath, nil
 }
 
 func validateZip(path string) error {
@@ -264,7 +264,7 @@ func extractSpecificJar(zipPath, extractTo string) error {
 
 	var jarFile *zip.File
 	for _, f := range zr.File {
-		if path.Base(f.Name) == driverFilename {
+		if f.FileInfo().Mode().IsRegular() && path.Base(f.Name) == driverFilename {
 			jarFile = f
 			break
 		}

--- a/crawler.go
+++ b/crawler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -263,7 +264,7 @@ func extractSpecificJar(zipPath, extractTo string) error {
 
 	var jarFile *zip.File
 	for _, f := range zr.File {
-		if f.Name == driverFilename {
+		if path.Base(f.Name) == driverFilename {
 			jarFile = f
 			break
 		}

--- a/crawler_test.go
+++ b/crawler_test.go
@@ -116,22 +116,30 @@ func TestExtractSpecificJar_NestedPath(t *testing.T) {
 	}
 }
 
-func createZipWithFile(zipPath, fileName, body string) error {
+func createZipWithFile(zipPath, fileName, body string) (err error) {
 	f, err := os.Create(zipPath)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
 	zw := zip.NewWriter(f)
-	defer zw.Close()
+	defer func() {
+		if cerr := zw.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
 	w, err := zw.Create(fileName)
 	if err != nil {
 		return err
 	}
 
-	if _, err := w.Write([]byte(body)); err != nil {
+	if _, err = w.Write([]byte(body)); err != nil {
 		return err
 	}
 

--- a/crawler_test.go
+++ b/crawler_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNormalizeURL(t *testing.T) {
 	t.Parallel()
@@ -89,4 +94,46 @@ func TestIsAllowedDriverDownloadURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractSpecificJar_NestedPath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "driver.zip")
+
+	if err := createZipWithFile(zipPath, "nested/dir/"+driverFilename, "jar-content"); err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+
+	if err := extractSpecificJar(zipPath, tmpDir); err != nil {
+		t.Fatalf("extractSpecificJar returned error: %v", err)
+	}
+
+	outPath := filepath.Join(tmpDir, "driver-"+driverFilename)
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected extracted jar at %s: %v", outPath, err)
+	}
+}
+
+func createZipWithFile(zipPath, fileName, body string) error {
+	f, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	w, err := zw.Create(fileName)
+	if err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte(body)); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- make ZIP search robust by matching path.Base(f.Name) against GoogleBigQueryJDBC42.jar
- keep extraction output naming unchanged
- add a test case where the JAR exists under nested directories inside ZIP

## Validation
- go test ./...