### PR TITLE
fix: normalize history/archive keys and add Go pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,20 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: gofmt -w
+        language: system
+        types: [go]
+      - id: go-vet
+        name: go vet
+        entry: go vet ./...
+        language: system
+        pass_filenames: false
+      - id: go-test
+        name: go test
+        entry: go test ./...
+        language: system
+        pass_filenames: false

--- a/crawler.go
+++ b/crawler.go
@@ -197,7 +197,7 @@ func isAllowedDriverDownloadURL(rawURL string) bool {
 func excludeOldDrivers(links []string) []string {
 	var out []string
 	for _, l := range links {
-		base := filepath.Base(l)
+		base := archiveFilename(l)
 		if _, found := excludeDriverList[base]; found {
 			continue
 		}
@@ -220,7 +220,10 @@ func downloadJDBCDriver(url, destDir string) (string, error) {
 		return "", fmt.Errorf("HTTP status %d", resp.StatusCode)
 	}
 
-	filename := filepath.Base(url)
+	filename := archiveFilename(url)
+	if filename == "" || filename == "." || filename == "/" {
+		return "", fmt.Errorf("invalid download filename: %s", url)
+	}
 	destPath := filepath.Join(destDir, filename)
 	f, err := os.Create(destPath)
 	if err != nil {
@@ -296,6 +299,8 @@ func extractSpecificJar(zipPath, extractTo string) error {
 }
 
 func isDownloaded(link string) (bool, error) {
+	targetKey := historyKey(link)
+
 	f, err := os.Open(historyFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -307,7 +312,14 @@ func isDownloaded(link string) (bool, error) {
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if strings.TrimSpace(s.Text()) == link {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+		// Backward-compatible check:
+		// - old format: full URL
+		// - new format: canonical history key (zip filename)
+		if line == link || historyKey(line) == targetKey {
 			return true, nil
 		}
 	}
@@ -318,13 +330,35 @@ func isDownloaded(link string) (bool, error) {
 }
 
 func appendToHistory(link string) error {
+	key := historyKey(link)
+
 	f, err := os.OpenFile(historyFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	if _, err := f.WriteString(link + "\n"); err != nil {
+	if _, err := f.WriteString(key + "\n"); err != nil {
 		return err
 	}
 	return nil
+}
+
+func historyKey(value string) string {
+	return archiveFilename(value)
+}
+
+func archiveFilename(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	u, err := url.Parse(trimmed)
+	if err == nil && u.Path != "" {
+		if base := path.Base(u.Path); base != "" && base != "." && base != "/" {
+			return base
+		}
+	}
+
+	return filepath.Base(trimmed)
 }

--- a/crawler_test.go
+++ b/crawler_test.go
@@ -116,6 +116,118 @@ func TestExtractSpecificJar_NestedPath(t *testing.T) {
 	}
 }
 
+func TestArchiveFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "url with query",
+			raw:  "https://storage.googleapis.com/simba-bq-jdbc-releases/SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip?download=1",
+			want: "SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip",
+		},
+		{
+			name: "plain filename",
+			raw:  "SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip",
+			want: "SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := archiveFilename(tc.raw)
+			if got != tc.want {
+				t.Fatalf("archiveFilename(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExcludeOldDrivers_WithQuery(t *testing.T) {
+	t.Parallel()
+
+	links := []string{
+		"https://storage.googleapis.com/simba-bq-jdbc-releases/SimbaJDBCDriverforGoogleBigQuery42_1.5.4.1008.zip?download=1",
+		"https://storage.googleapis.com/simba-bq-jdbc-releases/SimbaJDBCDriverforGoogleBigQuery42_9.9.9.9999.zip?download=1",
+	}
+	got := excludeOldDrivers(links)
+
+	if len(got) != 1 {
+		t.Fatalf("excludeOldDrivers length = %d, want 1", len(got))
+	}
+	if got[0] != links[1] {
+		t.Fatalf("excludeOldDrivers first = %q, want %q", got[0], links[1])
+	}
+}
+
+func TestIsDownloaded_BackwardCompatible(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir tmp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	oldHistoryLine := "https://storage.googleapis.com/simba-bq-jdbc-releases/SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip"
+	if err := os.WriteFile(historyFile, []byte(oldHistoryLine+"\n"), 0o644); err != nil {
+		t.Fatalf("write history: %v", err)
+	}
+
+	target := "https://example.com/mirror/SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip?x=1"
+	got, err := isDownloaded(target)
+	if err != nil {
+		t.Fatalf("isDownloaded: %v", err)
+	}
+	if !got {
+		t.Fatalf("expected backward-compatible match")
+	}
+}
+
+func TestAppendToHistory_WritesCanonicalKey(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir tmp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	link := "https://storage.googleapis.com/simba-bq-jdbc-releases/SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip?download=1"
+	if err := appendToHistory(link); err != nil {
+		t.Fatalf("appendToHistory: %v", err)
+	}
+
+	b, err := os.ReadFile(historyFile)
+	if err != nil {
+		t.Fatalf("ReadFile history: %v", err)
+	}
+	got := string(b)
+	want := "SimbaJDBCDriverforGoogleBigQuery42_1.6.3.1004.zip\n"
+	if got != want {
+		t.Fatalf("history content = %q, want %q", got, want)
+	}
+}
+
 func createZipWithFile(zipPath, fileName, body string) (err error) {
 	f, err := os.Create(zipPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- normalize archive filename extraction from URL paths (handles query params safely)
- use canonical archive key for download history to avoid duplicate downloads when URL changes
- keep backward compatibility with existing full-URL history entries
- add Go-focused pre-commit hooks: gofmt, go vet, go test
- extend tests for history key behavior and query-string URL handling

## Validation
- go test ./...
- go vet ./...