### PR TITLE
Add GitHub Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Follow these repository instructions when working in this project.
 
 - The main implementation lives in `crawler.go`.
 - Dependency management is defined in `go.mod` and `go.sum`.
-- Downloaded ZIP and JAR artifacts are written under `downloads/`.
+- Downloaded ZIP files are written to `downloads/`, and the main JAR is extracted from them into the same directory.
 - GitHub Actions workflows live under `.github/workflows/`.
 
 ## Validation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# GitHub Copilot Instructions
+
+Follow these repository instructions when working in this project.
+
+## General guidance
+
+- Keep changes focused and consistent with the current Go-based crawler workflow.
+- Write new or updated repository instructions, comments, and documentation in English.
+- Avoid local absolute paths, machine-specific assumptions, and hardcoded credentials.
+- Treat downloaded artifacts and runtime output as generated data, not hand-maintained source files.
+- Keep network fetching, extraction logic, and history tracking clearly separated.
+
+## Project context
+
+- The main implementation lives in `crawler.go`.
+- Dependency management is defined in `go.mod` and `go.sum`.
+- Downloaded ZIP and JAR artifacts are written under `downloads/`.
+- GitHub Actions workflows live under `.github/workflows/`.
+
+## Validation
+
+- Prefer `go test ./...` when tests exist or when new tests are added.
+- Prefer `go build ./...` for build verification after logic changes.
+- Clearly distinguish between checks you ran and checks you did not run.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "README.md,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
+applyTo: "**/*.md,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
 ---
 
 When editing documentation or workflow files in this repository:

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "README.md,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
+---
+
+When editing documentation or workflow files in this repository:
+
+- Keep documentation in English and aligned with the current crawler behavior.
+- Document required network access and generated output locations accurately.
+- Do not present local machine-specific steps as repository-wide requirements.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "*.go,go.mod,go.sum"
+---
+
+When editing Go files in this repository:
+
+- Keep the crawler logic easy to follow and centered on one responsibility per function.
+- Preserve stable handling for URL extraction, exclusion rules, downloads, and archive extraction.
+- Avoid baking environment-specific proxy or filesystem settings into source code.
+- Keep dependency changes deliberate and aligned with the crawler's actual needs.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -8,3 +8,4 @@ When editing Go files in this repository:
 - Preserve stable handling for URL extraction, exclusion rules, downloads, and archive extraction.
 - Avoid baking environment-specific proxy or filesystem settings into source code.
 - Keep dependency changes deliberate and aligned with the crawler's actual needs.
+- Write comments and user-facing strings (e.g., error messages, log output) in English.


### PR DESCRIPTION
## Summary
- add repository-wide GitHub Copilot instructions
- add path-specific instruction files for Go code, docs, and workflow files
- write the instruction content in English to match the top-level README language

## Testing
- not run (instruction files only)